### PR TITLE
Update alloy.js

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/tconstruct/alloy.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/tconstruct/alloy.js
@@ -9,16 +9,16 @@ onEvent('recipes', (event) => {
             inputs: [
                 {
                     tag: 'forge:pink_slime',
-                    amount: 144
+                    amount: 250
                 },
                 {
                     tag: 'tconstruct:ender_slime',
-                    amount: 144
+                    amount: 250
                 }
             ],
             result: {
                 fluid: 'kubejs:pink_ender_slime',
-                amount: 288
+                amount: 500
             },
             temperature: 1500,
             id: `${id_prefex}pink_ender_slime`


### PR DESCRIPTION
Change to increments of 250 as 144 is only used for ingots, and pink enderslime ingots don't exist.